### PR TITLE
Use LESS version ~1.5.0 in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "gitHead": "507383fe7771a092e8a7bcb23a9bd33c1904ce34",
   "dependencies": {
     "event-stream": "~3.0.15",
-    "less": "~1.4.1",
+    "less": "~1.5.0",
     "gulp-util": "0.0.1",
     "clone": "~0.1.9",
     "lodash": "~1.3.1"


### PR DESCRIPTION
What it says on the tin. Doesn't break anything for me, but now I can use sourceMaps :)
#3
