### PR TITLE
tree.toCSS may throw exception, which is not emitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,14 +22,13 @@ module.exports = function (options) {
     delete opts.compress;
     this.pause();
 
-    var parser = new less.Parser(opts);
     var str = file.contents.toString('utf8');
-    parser.parse(str, function (err, tree) {
+    less.render(str, opts, function (err, css) {
       if (err) {
         self.emit('error', new PluginError('gulp-less', err));
         return self.resume();
       }
-      file.contents = new Buffer(tree.toCSS(opts));
+      file.contents = new Buffer(css);
       file.path = gutil.replaceExtension(file.path, '.css');
       self.emit('data', file);
       self.resume();

--- a/test/compile-with-error.js
+++ b/test/compile-with-error.js
@@ -1,0 +1,28 @@
+var less = require('../');
+var should = require('should');
+var fs = require('fs');
+var path = require('path');
+var gutil = require('gulp-util');
+
+var filePath = path.join(__dirname, 'fixtures', 'test-with-error.less');
+var base = path.join(__dirname, 'fixtures');
+var cwd = __dirname;
+var file = new gutil.File({
+  cwd: cwd,
+  base: base,
+  path: filePath,
+  contents: fs.readFileSync(filePath)
+});
+
+describe('gulp-less', function () {
+  describe('less()', function () {
+    it('should emit error during compile', function (done) {
+      var stream = less();
+      stream.on('error', function (err) {
+        err.should.be.ok;
+        done();
+      });
+      stream.write(file);
+    });
+  });
+});

--- a/test/fixtures/test-with-error.less
+++ b/test/fixtures/test-with-error.less
@@ -1,0 +1,7 @@
+@import "variables.less";
+.test {
+  p {
+    font-size: @baseSize;
+    color: @undefinedVariable;
+  }
+}


### PR DESCRIPTION
`tree.toCSS` throws exception on less syntax error.
Imo, better to use `less.render` instead of `parser.parse`. Render uses parser internally and handles all errors. Added test case.
