### PR TITLE
Default `opts.paths` value for less.render

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var defaults = require('lodash.defaults');
 module.exports = function (options) {
   // Mixes in default options.
   options = defaults(options || {}, {
-    compress: false
+    compress: false,
+    paths: []
   });
 
   function transform (file, enc, next) {
@@ -31,7 +32,6 @@ module.exports = function (options) {
 
     // Injects the path of the current file.
     opts.filename = file.path;
-    opts.paths = opts.paths || [];
 
     less.render(str, opts, function (err, css) {
       if (err) {


### PR DESCRIPTION
This commit fixes https://github.com/plus3network/gulp-less/issues/40.

It seems, the problem is in original Less module: there is no default value for `env.paths` or any checks for that. So this fix is temporary.

Now I’m going to create pull-request for Less fixing the issue. Stay tuned, guys.
