### PR TITLE
Add an option for custom functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ gulp.task('less', function () {
 
 ## Options
 
-The options are the same as what's supported by the less parser. Please note that this plugin only generates inline sourcemaps (with `sourceMap: true`) - specifying a `sourceMapFilename` option will do nothing.
+The options are the same as what's supported by the less parser. Please note that this plugin only generates inline sourcemaps (with `sourceMap: true`) - specifying a `sourceMapFilename` option will do nothing. 
+
+`options.customFunctions` Define custom functions to be available within your LESS stylesheets. The function's name must be lowercase. In the definition, the first argument is the less object, and subsequent arguments are from the less function call. Values passed to the function are types defined within less, the return value may be either one of them or primitive. See the LESS documentation for more information on the available types.
 
 ## Error handling
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,17 @@ module.exports = function (options) {
     // Injects the path of the current file.
     opts.filename = file.path;
 
+    // Load custom functions
+    if (opts.customFunctions) {
+      Object.keys(opts.customFunctions).forEach(function(name) {
+        less.tree.functions[name.toLowerCase()] = function() {
+          var args = [].slice.call(arguments);
+          args.unshift(less);
+          return new less.tree.Anonymous(options.customFunctions[name].apply(this, args));
+        };
+      });
+    }
+
     less.render(str, opts, function (err, css) {
       if (err) {
 

--- a/test/expect/customFunctions.css
+++ b/test/expect/customFunctions.css
@@ -1,0 +1,5 @@
+.myRule {
+  background-color: red;
+  width: 5px;
+  background: "Hello";
+}

--- a/test/fixtures/customFunctions.less
+++ b/test/fixtures/customFunctions.less
@@ -1,0 +1,5 @@
+.myRule {
+	background-color: get-color(red);
+	width: multiple-args(1px, 4px);
+	background: string-result(3);
+}

--- a/test/main.js
+++ b/test/main.js
@@ -120,5 +120,41 @@ describe('gulp-less', function () {
         stream.write(file);
       });
     });
+
+    it('should compile custom functions', function(done) {
+      var files = [
+        createVinyl('customFunctions.less')
+      ];
+
+      var stream = less({
+        customFunctions: {
+          'get-color': function(less, color) {
+            return 'red';
+          },
+          'multiple-args': function(less, arg1, arg2) {
+            return (((arg1.value * 1) + (arg2.value))) + arg1.unit.numerator[0];
+          },
+          'string-result': function(less, arg1) {
+              return "\"Hello\"";
+          }
+        }
+      });
+
+      var count = files.length;
+      stream.on('data', function (cssFile) {
+        should.exist(cssFile);
+        should.exist(cssFile.path);
+        should.exist(cssFile.relative);
+        should.exist(cssFile.contents);
+        String(cssFile.contents).should.equal(
+          fs.readFileSync(pj(__dirname, 'expect/customFunctions.css'), 'utf8'));
+
+        if (!--count) { done(); }
+      });
+
+      files.forEach(function (file) {
+        stream.write(file);
+      });
+    });
   });
 });


### PR DESCRIPTION
Add an option for custom functions to be passed to the less processor. There is a similar method available in grunt-contrib-less. Includes a test.
