### PR TITLE
Remove travis test with node 0.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.9"


### PR DESCRIPTION
Travis does not provide Node 0.9 anymore.

http://docs.travis-ci.com/user/ci-environment/#Node.js-VM-images
