### PR TITLE
Add './bower_components' to options.paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ module.exports = function (options) {
     paths: []
   });
 
+  // Add .bower_components to include paths.
+  options.paths.push('./bower_components')
+  
   function transform (file, enc, next) {
     var self = this;
 


### PR DESCRIPTION
This makes working with bower projects magical. Just do `@import "projectName/path/to/partial.less"`. A good example is `@import "bootstrap/less/bootstrap.less".
