### PR TITLE
Fix source mapping: make source path relative

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,11 @@ module.exports = function (options) {
           var comment = convert.fromSource(css);
           if (comment) {
             file.contents = new Buffer(convert.removeComments(css));
-            applySourceMap(file, comment.sourcemap);
+            var sourceMap = comment.sourcemap;
+            for (var i = 0; i < sourceMap.sources.length; i++) {
+              sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]);
+            }
+            applySourceMap(file, sourceMap);
           }
         }
 


### PR DESCRIPTION
`gulp-less` puts an absolute path into the `sources` property of the source map. But it needs to be relative for `applySourceMap` (and the browser) to work properly.
Fixes #63
