### PR TITLE
Fix Windows Source Path

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function (options) {
             file.contents = new Buffer(convert.removeComments(css));
             var sourceMap = comment.sourcemap;
             for (var i = 0; i < sourceMap.sources.length; i++) {
-              sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]).replace(/\\/g,"/");
+              sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]).replace(/\\/g,'/');
             }
             applySourceMap(file, sourceMap);
           }


### PR DESCRIPTION
This PR normalizes Windows backslashes in the sources array to normal backslashes.
refs https://github.com/floridoo/gulp-sourcemaps/issues/26

Thanks!
Max
