### PR TITLE
Compatibility fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,10 +59,10 @@ module.exports = function (options) {
           if (comment) {
             file.contents = new Buffer(convert.removeComments(css));
             var sourceMap = comment.sourcemap;
+            sourceMap.file = unixStylePath(file.relative);
             for (var i = 0; i < sourceMap.sources.length; i++) {
-              sourceMap.sources[i] = path.relative(file.base, sourceMap.sources[i]);
+              sourceMap.sources[i] = unixStylePath(path.relative(file.base, sourceMap.sources[i]));
             }
-            sourceMap.file = file.relative;
             applySourceMap(file, sourceMap);
           }
         }
@@ -73,4 +73,6 @@ module.exports = function (options) {
   });
 };
 
-
+function unixStylePath(filePath) {
+  return filePath.split(path.sep).join('/');
+}


### PR DESCRIPTION
In my setup, I've tried using gulp-less in front of the following plugins:
- gulp-postcss
- gulp-autoprefixer
- gulp-pleeease

All of them use vinyl-sourcemaps-apply (probably most sourcemap aware gulp plugins do anyway), and all exhibit the same behavior:

```
/var/www/test/node_modules/gulp-postcss/node_modules/vinyl-sourcemaps-apply/node_modules/source-map/lib/source-map/source-map-generator.js:171
          throw new Error(
                ^
Error: SourceMapGenerator.prototype.applySourceMap requires either an explicit source file, or the source map's "file" property. Both were omitted.
    at SourceMapGenerator_applySourceMap [as applySourceMap] (/var/www/test/node_modules/gulp-postcss/node_modules/vinyl-sourcemaps-apply/node_modules/source-map/lib/source-map/source-map-generator.js:171:17)
    at applySourceMap (/var/www/test/node_modules/gulp-postcss/node_modules/vinyl-sourcemaps-apply/index.js:23:15)
    at DestroyableTransform.transform [as _transform] (/var/www/test/node_modules/gulp-postcss/index.js:58:7)
    at DestroyableTransform.Transform._read (/var/www/test/node_modules/gulp-postcss/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/var/www/test/node_modules/gulp-postcss/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/var/www/test/node_modules/gulp-postcss/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/var/www/test/node_modules/gulp-postcss/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/var/www/test/node_modules/gulp-postcss/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/var/www/test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/var/www/test/node_modules/gulp-less/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
```

Not sure if this was always the case, or a recent change to vinyl-sourcemaps-apply broke gulp-less, but the fix is easy-enough: just add the missing property into the generated sourcemaps.

Additionally, I've taken the liberty of converting all filesystem delimiters to unix format, as that is the cannonical format used on the web. In fact, vinyl-sourcemaps-apply doesn't properly merge two source maps unless they use the same path convention, and while that's technically not gulp-less's problem, the change doesn't seem to break anything else.
