### PR TITLE
revert moving the replaceExt to after sourcemaps are applied

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ module.exports = function (options) {
 
           file.contents = new Buffer(css);
 
+          file.path = gutil.replaceExtension(file.path, '.css');
+
           if (file.sourceMap) {
             var comment = convert.fromSource(css);
             if (comment) {
@@ -57,8 +59,6 @@ module.exports = function (options) {
               applySourceMap(file, sourceMap);
             }
           }
-
-          file.path = gutil.replaceExtension(file.path, '.css');
 
           cb(null, file);
     }, function(err){


### PR DESCRIPTION
Move replacing the extension to after the sourcemaps are applied.

Closes #107 
