### PR TITLE
Added less.logError utility to fix gulp.watch termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This behaviour will terminate a gulp.watch, so to log the error and continue:
   .pipe(less().on('error',less.logError))
 ```
 
-To handle errors all errors from the chain with one handler, check out the error 
+To handle all errors from the chain with one handler, check out the error 
 handling documentation [here](https://github.com/gulpjs/gulp/blob/master/docs/recipes/combining-streams-to-handle-errors.md)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -105,7 +105,15 @@ gulp.src('./less/**/*.less')
 
 ## Error Handling
 
-By default, a gulp task will fail and all streams will halt when an error happens. To change this behavior check out the error handling documentation [here](https://github.com/gulpjs/gulp/blob/master/docs/recipes/combining-streams-to-handle-errors.md)
+By default, a gulp task will fail and all streams will halt when an error happens. 
+This behaviour will terminate a gulp.watch, so to log the error and continue:
+
+```js
+  .pipe(less().on('error',less.logError))
+```
+
+To handle errors all errors from the chain with one handler, check out the error 
+handling documentation [here](https://github.com/gulpjs/gulp/blob/master/docs/recipes/combining-streams-to-handle-errors.md)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -59,3 +59,8 @@ module.exports = function (options) {
     });
   });
 };
+
+module.exports.logError = function (error) {
+  gutil.log(error.toString());
+  this.emit('end');
+};


### PR DESCRIPTION
The fact that less errors were breaking my gulp.watch has been on my to do list for months.  Having finally gotten around to dealing with it, I spent an hour or two googling and reading forums figuring out the finer points of error handling.  When I saw that gulp-sass provided and documented a simple solution I was disappointed by the gulp-less documentation that just passed the error-handling-buck back to a less then obvious gulp recipe.

I've added a less.logError utility, in the same vein as the sass.logError, and updated the documentation.
