### PR TITLE
Add output file timestamps for Gulp 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ sudo: false
 
 language: node_js
 node_js:
-  - "0.10"
   - "6"
-  - "7"
+  - "8"
+  - "9"

--- a/index.js
+++ b/index.js
@@ -47,6 +47,12 @@ module.exports = function (options) {
       }
       return file;
     }).then(function(file) {
+      if (file.stat) {
+        // Add output file modification timestamps for Gulp 4+ support
+        var now = new Date();
+        file.stat.atime = now;
+        file.stat.mtime = now;
+      }
       cb(null, file);
     }).catch(function(err) {
       // Convert the keys so PluginError can read them


### PR DESCRIPTION
Fixes #301.
This modification sets the `atime` and `mtime` timestamp properties so that Vinyl will set the file times on disk correctly.
This happened by default in earlier versions of Gulp, but is no longer automatic in Gulp 4.