### PR TITLE
Set appropriate file.stat times

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ module.exports = function (options) {
     less.render(str, opts).then(function(res) {
       file.contents = new Buffer(res.result);
       file.path = replaceExt(file.path, '.css');
+      if (file.stat) {
+        file.stat.atime = file.stat.mtime = file.stat.ctime = new Date();
+      }
       if (res.sourcemap) {
         res.sourcemap.file = file.relative;
         res.sourcemap.sources = res.sourcemap.sources.map(function (source) {


### PR DESCRIPTION
Since we are outputting a destination file, we must set the appropriate file.stat times.
Fixes #301 